### PR TITLE
[REFACTOR] #85 - 테스트 코드 단위별로 분리

### DIFF
--- a/app/src/test/java/org/woowatechcamp/githubapplication/auth/TestAuthViewModel.kt
+++ b/app/src/test/java/org/woowatechcamp/githubapplication/auth/TestAuthViewModel.kt
@@ -17,6 +17,9 @@ class TestAuthViewModel {
     private lateinit var authViewModel : SignInViewModel
     private lateinit var authRepository : FakeAuthRepository
 
+    private val code = "code"
+    private val token = "token"
+
     @ExperimentalCoroutinesApi
     @get:Rule
     var mainCoroutineRule = MainCoroutineRule()
@@ -31,23 +34,25 @@ class TestAuthViewModel {
     }
 
     @Test
-    fun test_auth_viewModel() = runTest {
-        val code = "code"
-        val token = "token"
-
-        // empty test
+    fun test_auth_empty() = runTest {
         assertEquals(UiState.Empty, authViewModel.signInState.value)
+    }
 
-        // null test
+    @Test
+    fun test_auth_null() = runTest {
         authViewModel.getToken(code)
         assertEquals(UiState.Error("Test Null"), authViewModel.signInState.value)
+    }
 
-        // value test
+    @Test
+    fun test_auth_value() = runTest {
         authRepository.addToken(token)
         authViewModel.getToken(code)
         assertEquals(UiState.Success(token), authViewModel.signInState.value)
+    }
 
-        // error test
+    @Test
+    fun test_auth_error() = runTest {
         authRepository.setReturnError(true)
         authViewModel.getToken(code)
         assertEquals(UiState.Error("Test Error"), authViewModel.signInState.value)

--- a/app/src/test/java/org/woowatechcamp/githubapplication/issue/TestIssueViewModel.kt
+++ b/app/src/test/java/org/woowatechcamp/githubapplication/issue/TestIssueViewModel.kt
@@ -21,6 +21,47 @@ class TestIssueViewModel {
     private lateinit var issueRepository : FakeIssueRepository
     private lateinit var issueUseCase: FakeIssueUseCase
 
+    private var state = "open"
+
+    private val issues = listOf(
+        IssueModel(
+            id = 0,
+            state = IssueState.getIssueState("open"),
+            name = "Issue",
+            fullName = "Full Issue",
+            number = "#1",
+            title = "Issue Title",
+            timeDiff = "2일 전"
+        ),
+        IssueModel(
+            id = 0,
+            state = IssueState.getIssueState("closed"),
+            name = "Issue",
+            fullName = "Full Issue",
+            number = "#2",
+            title = "Issue Title",
+            timeDiff = "2일 전"
+        ),
+        IssueModel(
+            id = 0,
+            state = IssueState.getIssueState("open"),
+            name = "Issue",
+            fullName = "Full Issue",
+            number = "#3",
+            title = "Issue Title",
+            timeDiff = "2일 전"
+        ),
+        IssueModel(
+            id = 0,
+            state = IssueState.getIssueState("closed"),
+            name = "Issue",
+            fullName = "Full Issue",
+            number = "#4",
+            title = "Issue Title",
+            timeDiff = "2일 전"
+        )
+    )
+
     @ExperimentalCoroutinesApi
     @get:Rule
     var mainCoroutineRule = MainCoroutineRule()
@@ -33,75 +74,43 @@ class TestIssueViewModel {
         issueRepository = FakeIssueRepository()
         issueUseCase = FakeIssueUseCase()
         issueViewModel = IssueViewModel(issueRepository, issueUseCase)
+        issueUseCase.addIssues(issues)
     }
 
     @Test
-    fun test_issue_viewModel() = runTest {
-
-        var state = "open"
-
-        val issues = listOf(
-            IssueModel(
-                id = 0,
-                state = IssueState.getIssueState("open"),
-                name = "Issue",
-                fullName = "Full Issue",
-                number = "#1",
-                title = "Issue Title",
-                timeDiff = "2일 전"
-            ),
-            IssueModel(
-                id = 0,
-                state = IssueState.getIssueState("closed"),
-                name = "Issue",
-                fullName = "Full Issue",
-                number = "#2",
-                title = "Issue Title",
-                timeDiff = "2일 전"
-            ),
-            IssueModel(
-                id = 0,
-                state = IssueState.getIssueState("open"),
-                name = "Issue",
-                fullName = "Full Issue",
-                number = "#3",
-                title = "Issue Title",
-                timeDiff = "2일 전"
-            ),
-            IssueModel(
-                id = 0,
-                state = IssueState.getIssueState("closed"),
-                name = "Issue",
-                fullName = "Full Issue",
-                number = "#4",
-                title = "Issue Title",
-                timeDiff = "2일 전"
-            )
-        )
-
-        issueUseCase.addIssues(issues)
-
+    fun test_issue_null() = runTest {
         issueViewModel.issueState.test {
-            // null test
             issueViewModel.getIssues(state)
             assertEquals(UiState.Error("Test Null"), awaitItem())
+        }
+    }
 
-            // open value test
+    @Test
+    fun test_issue_value_open() = runTest {
+        issueViewModel.issueState.test {
             issueRepository.addIssues(issues)
             issueViewModel.getIssues(state)
             assertEquals(
                 UiState.Success(issues.filter { issue -> issue.state.state == "open" }),
                 awaitItem())
+        }
+    }
 
-            // closed value test
+    @Test
+    fun test_issue_value_closed() = runTest {
+        issueViewModel.issueState.test {
             state = "closed"
             issueRepository.addIssues(issues)
             issueViewModel.getIssues(state)
             assertEquals(
                 UiState.Success(issues.filter { issue -> issue.state.state == "closed" }),
                 awaitItem())
+        }
+    }
 
-            // error test
+    @Test
+    fun test_issue_error() = runTest {
+        issueViewModel.issueState.test {
             issueRepository.setReturnError(true)
             issueViewModel.getIssues(state)
             assertEquals(UiState.Error("Test Error"), awaitItem())

--- a/app/src/test/java/org/woowatechcamp/githubapplication/notification/TestNotiViewModel.kt
+++ b/app/src/test/java/org/woowatechcamp/githubapplication/notification/TestNotiViewModel.kt
@@ -20,6 +20,53 @@ class TestNotiViewModel {
     private lateinit var notiRepository: FakeNotiRepository
     private lateinit var notiUseCase : FakeNotiUseCase
 
+    private val threadId = "Hello"
+    private val notiList = listOf(
+        NotiModel(
+            id = "creative",
+            name = "duck",
+            fullName = "creativeduck",
+            title = "Noti Test",
+            timeDiff = "1일 전",
+            imgUrl = "https://hello",
+            num = "#0",
+            commentNum = 0,
+            url = "https://bye",
+            timeDiffNum = 100L,
+            repo = "/repo",
+            threadId = "10101"
+        ),
+        NotiModel(
+            id = "creative",
+            name = "duck",
+            fullName = "creativeduck",
+            title = "Noti Test",
+            timeDiff = "1일 전",
+            imgUrl = "https://hello",
+            num = "#0",
+            commentNum = 1,
+            url = "https://bye",
+            timeDiffNum = 100L,
+            repo = "/repo",
+            threadId = "10101"
+        )
+    )
+
+    private val refreshNotiModel = NotiModel(
+        id = "creative",
+        name = "duck",
+        fullName = "creativeduck",
+        title = "Noti Test",
+        timeDiff = "1일 전",
+        imgUrl = "https://hello",
+        num = "#0",
+        commentNum = 3,
+        url = "https://bye",
+        timeDiffNum = 100L,
+        repo = "/repo",
+        threadId = "10101"
+    )
+
     @ExperimentalCoroutinesApi
     @get:Rule
     var mainCoroutineRule = MainCoroutineRule()
@@ -36,125 +83,110 @@ class TestNotiViewModel {
     }
 
     @Test
-    fun test_noti_viewModel() = runTest {
-
-        val threadId = "Hello"
-        val notiList = listOf(
-            NotiModel(
-                id = "creative",
-                name = "duck",
-                fullName = "creativeduck",
-                title = "Noti Test",
-                timeDiff = "1일 전",
-                imgUrl = "https://hello",
-                num = "#0",
-                commentNum = 0,
-                url = "https://bye",
-                timeDiffNum = 100L,
-                repo = "/repo",
-                threadId = "10101"
-            ),
-            NotiModel(
-                id = "creative",
-                name = "duck",
-                fullName = "creativeduck",
-                title = "Noti Test",
-                timeDiff = "1일 전",
-                imgUrl = "https://hello",
-                num = "#0",
-                commentNum = 1,
-                url = "https://bye",
-                timeDiffNum = 100L,
-                repo = "/repo",
-                threadId = "10101"
-            )
-        )
-
-        val refreshNotiModel = NotiModel(
-            id = "creative",
-            name = "duck",
-            fullName = "creativeduck",
-            title = "Noti Test",
-            timeDiff = "1일 전",
-            imgUrl = "https://hello",
-            num = "#0",
-            commentNum = 3,
-            url = "https://bye",
-            timeDiffNum = 100L,
-            repo = "/repo",
-            threadId = "10101"
-        )
-
-        // notifications test
+    fun test_noti_loading() = runTest {
         notiViewModel.notiState.test {
-
-            // loading test
             notiViewModel.getNoti()
             assertEquals(UiState.Loading, awaitItem())
             assertEquals(UiState.Error("Test Null"), awaitItem())
+        }
+    }
 
-            // value test
+    @Test
+    fun test_noti_value() = runTest {
+        notiViewModel.notiState.test {
             notiRepository.addNoties(notiList)
             notiViewModel.getNoti()
             assertEquals(UiState.Loading, awaitItem())
             assertEquals(UiState.Success(notiList), awaitItem())
+        }
+    }
 
-            // error test
+    @Test
+    fun test_noti_erro() = runTest {
+        notiViewModel.notiState.test {            // error test
             notiRepository.setReturnError(true)
             notiViewModel.getNoti()
             assertEquals(UiState.Loading, awaitItem())
             assertEquals(UiState.Error("Test Error"), awaitItem())
         }
-        notiRepository.setReturnError(false)
+    }
 
-        // comment test
+    @Test
+    fun test_comment_null() = runTest {
         notiViewModel.notiCommentState.test {
-            // null test
+            notiViewModel.getComments(refreshNotiModel)
             assertEquals(UiState.Error("Test Null"), awaitItem())
+        }
+    }
 
-            // value test
+    @Test
+    fun test_comment_value() = runTest {
+        notiViewModel.notiCommentState.test {
             notiRepository.addCommentNoti(refreshNotiModel)
             notiViewModel.getComments(refreshNotiModel)
             assertEquals(UiState.Success(refreshNotiModel), awaitItem())
+        }
+    }
 
-            // error test
+    @Test
+    fun test_comment_error() = runTest {
+        notiViewModel.notiCommentState.test {
             notiRepository.setReturnError(true)
             notiViewModel.getComments(refreshNotiModel)
             assertEquals(UiState.Error("Test Error"), awaitItem())
         }
-        notiRepository.setReturnError(false)
+    }
 
-        // mark test
+    @Test
+    fun test_mark_null() = runTest {
         notiViewModel.markState.test {
-            // null test
             notiViewModel.markNoti(threadId)
             assertEquals(UiState.Error("Test Null"), awaitItem())
+        }
+    }
 
-            // value 205 test
+    @Test
+    fun test_mark_value_205() = runTest {
+        notiViewModel.markState.test {
             notiRepository.setStatus(205)
             notiViewModel.markNoti(threadId)
             assertEquals(UiState.Success("Success"), awaitItem())
+        }
+    }
 
-            // value 304 test
+    @Test
+    fun test_mark_value_304() = runTest {
+        notiViewModel.markState.test {
             notiRepository.setStatus(304)
             notiViewModel.markNoti(threadId)
             assertEquals(UiState.Error("Not Modified"), awaitItem())
+        }
+    }
 
-            // value 403 test
+    @Test
+    fun test_mark_value_403() = runTest {
+        notiViewModel.markState.test {
             notiRepository.setStatus(403)
             notiViewModel.markNoti(threadId)
             assertEquals(UiState.Error("Forbidden"), awaitItem())
+        }
+    }
 
-            // value else test
+    @Test
+    fun test_mark_value_other_status() = runTest {
+        notiViewModel.markState.test {
             notiRepository.setStatus(500)
             notiViewModel.markNoti(threadId)
             assertEquals(UiState.Error("Status Error"), awaitItem())
+        }
+    }
 
-            // error test
+    @Test
+    fun test_mark_error() = runTest {
+        notiViewModel.markState.test {
             notiRepository.setReturnError(true)
             notiViewModel.markNoti(threadId)
             assertEquals(UiState.Error("Test Error"), awaitItem())
         }
-
     }
 }

--- a/app/src/test/java/org/woowatechcamp/githubapplication/user/TestMainViewModel.kt
+++ b/app/src/test/java/org/woowatechcamp/githubapplication/user/TestMainViewModel.kt
@@ -18,6 +18,19 @@ class TestMainViewModel {
     private lateinit var mainViewModel: MainViewModel
     private lateinit var userRepository : FakeMainRepository
 
+    private val userData = UserModel(
+        name = "Helllo",
+        nickname = "hello",
+        bio = "bio",
+        location = "location",
+        blog = "blog",
+        email = "email",
+        imgUrl = "imgUrl",
+        followInfo = "follow",
+        repoNum = 12,
+        starredNum = 3
+    )
+
     @ExperimentalCoroutinesApi
     @get:Rule
     var mainCoroutineRule = MainCoroutineRule()
@@ -32,23 +45,12 @@ class TestMainViewModel {
     }
 
     @Test
-    fun test_user_viewModel() = runTest {
-        val userData = UserModel(
-            name = "Helllo",
-            nickname = "hello",
-            bio = "bio",
-            location = "location",
-            blog = "blog",
-            email = "email",
-            imgUrl = "imgUrl",
-            followInfo = "follow",
-            repoNum = 12,
-            starredNum = 3
-        )
-        // user empty test
+    fun test_user_empty_value() = runTest {
         assertEquals(UiState.Empty, mainViewModel.mainState.value)
+    }
 
-        // profile empty test
+    @Test
+    fun test_profile_empty_value() = runTest {
         mainViewModel.profile.test {
             mainViewModel.getProfile()
             assertEquals(
@@ -56,12 +58,17 @@ class TestMainViewModel {
                 awaitItem()
             )
         }
+    }
 
-        // user null value test
+    @Test
+    fun test_user_null_value() = runTest {
         mainViewModel.getUser()
         assertEquals(UiState.Error("Test Null"), mainViewModel.mainState.value)
+    }
 
-        // profile null value test
+    @Test
+    fun test_profile_null_value() = runTest {
+        mainViewModel.getUser()
         mainViewModel.profile.test {
             mainViewModel.getProfile()
             assertEquals(
@@ -69,13 +76,19 @@ class TestMainViewModel {
                 awaitItem()
             )
         }
+    }
 
-        // user value test
+    @Test
+    fun test_user_value_test() = runTest {
         userRepository.addUser(userData)
         mainViewModel.getUser()
         assertEquals(UiState.Success(userData), mainViewModel.mainState.value)
+    }
 
-        // profile value test
+    @Test
+    fun test_profile_value_test() = runTest {
+        userRepository.addUser(userData)
+        mainViewModel.getUser()
         mainViewModel.profile.test {
             mainViewModel.getProfile()
             assertEquals(
@@ -83,13 +96,19 @@ class TestMainViewModel {
                 awaitItem()
             )
         }
+    }
 
-        // user error test
+    @Test
+    fun test_user_error_test() = runTest {
         userRepository.setReturnError(true)
         mainViewModel.getUser()
         assertEquals(UiState.Error("Test Error"), mainViewModel.mainState.value)
+    }
 
-        // profile erro test
+    @Test
+    fun test_profile_error_test() = runTest {
+        userRepository.setReturnError(true)
+        mainViewModel.getUser()
         mainViewModel.profile.test {
             mainViewModel.getProfile()
             assertEquals(


### PR DESCRIPTION
## Related issue 🚀
- closed #85 

## Work Description 💚
테스트 코드를 기존에는 하나의 함수에서 모든 viewModel 의 함수를 테스트했으나,
이걸 단위 별로 분리하도록 했습니다.